### PR TITLE
Add new ui settings fields to test fixture JSON files

### DIFF
--- a/json/settings/settings-default.json
+++ b/json/settings/settings-default.json
@@ -435,7 +435,11 @@
         "map_settings_expanded" : true,
         "timeline_expanded" : true,
         "main_ui_state" : "",
-        "main_ui_geometry" : ""
+        "main_ui_geometry" : "",
+        "map_pane_splitter_state" : "",
+        "map_pane_popout_state" : "",
+        "map_pane_view_link_state" : "",
+        "panes_match_map_style" : true
     },
     "unit" : {
         "accumulation_units" : "inches",

--- a/json/settings/settings-keax.json
+++ b/json/settings/settings-keax.json
@@ -402,6 +402,7 @@
         "sti_forecast_enabled" : true,
         "sti_past_enabled" : true,
         "thresholds" : {
+
         }
     },
     "text" : {
@@ -435,7 +436,11 @@
         "map_settings_expanded" : true,
         "timeline_expanded" : true,
         "main_ui_state" : "",
-        "main_ui_geometry" : ""
+        "main_ui_geometry" : "",
+        "map_pane_splitter_state" : "",
+        "map_pane_popout_state" : "",
+        "map_pane_view_link_state" : "",
+        "panes_match_map_style" : true
     },
     "unit" : {
         "accumulation_units" : "inches",

--- a/json/settings/settings-maps.json
+++ b/json/settings/settings-maps.json
@@ -443,7 +443,11 @@
         "map_settings_expanded" : true,
         "timeline_expanded" : true,
         "main_ui_state" : "",
-        "main_ui_geometry" : ""
+        "main_ui_geometry" : "",
+        "map_pane_splitter_state" : "",
+        "map_pane_popout_state" : "",
+        "map_pane_view_link_state" : "",
+        "panes_match_map_style" : true
     },
     "unit" : {
         "accumulation_units" : "inches",

--- a/json/settings/settings-maximum.json
+++ b/json/settings/settings-maximum.json
@@ -445,7 +445,11 @@
         "map_settings_expanded" : true,
         "timeline_expanded" : true,
         "main_ui_state" : "",
-        "main_ui_geometry" : ""
+        "main_ui_geometry" : "",
+        "map_pane_splitter_state" : "",
+        "map_pane_popout_state" : "",
+        "map_pane_view_link_state" : "",
+        "panes_match_map_style" : true
     },
     "unit" : {
         "accumulation_units" : "inches",

--- a/json/settings/settings-minimum.json
+++ b/json/settings/settings-minimum.json
@@ -445,7 +445,11 @@
         "map_settings_expanded" : true,
         "timeline_expanded" : true,
         "main_ui_state" : "",
-        "main_ui_geometry" : ""
+        "main_ui_geometry" : "",
+        "map_pane_splitter_state" : "",
+        "map_pane_popout_state" : "",
+        "map_pane_view_link_state" : "",
+        "panes_match_map_style" : true
     },
     "unit" : {
         "accumulation_units" : "inches",


### PR DESCRIPTION
The four new UiSettings variables (map_pane_splitter_state, map_pane_popout_state, map_pane_view_link_state, panes_match_map_style) were missing from the golden test data files, causing SettingsManager tests to fail when comparing generated output to expected JSON.